### PR TITLE
Avoid using log.Fatal (which calls os.Exit)

### DIFF
--- a/tm-tool/textmapper/resources/org/textmapper/tool/templates/go_types.ltp
+++ b/tm-tool/textmapper/resources/org/textmapper/tool/templates/go_types.ltp
@@ -41,7 +41,7 @@ ${if tokens = opts.reportTokens
 ${end-}
 ${call customRules-}
 	}
-	"log".Fatalf("unknown node type %v\n", n.Type())
+	panic("fmt".Errorf("ast: unknown node type %v", n.Type()))
 	return nil
 }
 ${end}


### PR DESCRIPTION
Hi! Nice project, I found this through @mewmew's efforts with LLVM.

I just came across this `log.Fatal` - it's not a great thing for a library to do, because it is difficult to tell where the program is exiting, as a consumer of this API. It would be better to panic, which would at least provide a stack trace.