### PR TITLE
Always prefix tokens containing non-ASCII characters with "char".

### DIFF
--- a/tm-go/grammar/id.go
+++ b/tm-go/grammar/id.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strings"
 	"unicode"
-	"unicode/utf8"
 )
 
 // nameStyle enumerates all supported identifier styles.
@@ -82,14 +81,18 @@ func SymbolID(name string, style nameStyle) string {
 			buf.WriteString(strings.ToUpper(word))
 		}
 	}
-	if inQuotes && len(name) == 1 {
-		r, _ := utf8.DecodeRuneInString(name)
-		if _, ok := charName[r]; !ok {
-			write("char")
-			if style == UpperCase {
-				// Insert an underscore anyway, as with UpperUnderscores.
-				buf.WriteByte('_')
-			}
+	hasNonASCII := false
+	for _, r := range name {
+		if _, ok := charName[r]; ok {
+			hasNonASCII = true
+			break
+		}
+	}
+	if hasNonASCII {
+		write("char")
+		if style == UpperCase {
+			// Insert an underscore anyway, as with UpperUnderscores.
+			buf.WriteByte('_')
 		}
 	}
 	var cont bool

--- a/tm-go/grammar/id.go
+++ b/tm-go/grammar/id.go
@@ -81,14 +81,7 @@ func SymbolID(name string, style nameStyle) string {
 			buf.WriteString(strings.ToUpper(word))
 		}
 	}
-	hasNonASCII := false
-	for _, r := range name {
-		if _, ok := charName[r]; ok {
-			hasNonASCII = true
-			break
-		}
-	}
-	if hasNonASCII {
+	if !isIdent(name) {
 		write("char")
 		if style == UpperCase {
 			// Insert an underscore anyway, as with UpperUnderscores.
@@ -129,4 +122,23 @@ func SymbolID(name string, style nameStyle) string {
 		write(word)
 	}
 	return buf.String()
+}
+
+// isIdent reports whether the given name is a valid Go identifier.
+func isIdent(name string) bool {
+	// From https://golang.org/ref/spec#Identifiers
+	//
+	//    identifier = letter { letter | unicode_digit } .
+	//    letter     = unicode_letter | "_" .
+	for i, r := range name {
+		isLetter := unicode.IsLetter(r) || r == '_'
+		if i == 0 && !isLetter {
+			return false
+		}
+		isDigit := unicode.IsDigit(r)
+		if !isLetter && !isDigit {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
This helps avoid name collisions in the generated Go source code.

Given a grammar with the two tokens 'or' and '|', the textmapper now
produces the following Go source code.

	OR      // or
	CHAR_OR // |

Note, this same method is used also to distinguish multi-character tokens
containing non-ASCII characters, e.g. a '...' token is distinguished from
a 'dotdotdot' token as per:

	DOTDOTDOT      // dotdotdot
	CHAR_DOTDOTDOT // ...

Fixes #31.