### PR TITLE
all: format source code and import statements using goimports

### DIFF
--- a/tm-go/gen/post_test.go
+++ b/tm-go/gen/post_test.go
@@ -1,8 +1,9 @@
 package gen_test
 
 import (
-	"github.com/inspirer/textmapper/tm-go/gen"
 	"testing"
+
+	"github.com/inspirer/textmapper/tm-go/gen"
 )
 
 func TestFormat(t *testing.T) {

--- a/tm-go/parsers/test/ast/factory.go
+++ b/tm-go/parsers/test/ast/factory.go
@@ -4,6 +4,7 @@ package ast
 
 import (
 	"fmt"
+
 	"github.com/inspirer/textmapper/tm-go/parsers/test"
 )
 

--- a/tm-go/parsers/test/parser_test.go
+++ b/tm-go/parsers/test/parser_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"context"
+
 	"github.com/inspirer/textmapper/tm-go/parsers/test"
 	"github.com/inspirer/textmapper/tm-parsers/parsertest"
 )

--- a/tm-go/syntax/expand_test.go
+++ b/tm-go/syntax/expand_test.go
@@ -1,8 +1,9 @@
 package syntax_test
 
 import (
-	"github.com/inspirer/textmapper/tm-go/syntax"
 	"testing"
+
+	"github.com/inspirer/textmapper/tm-go/syntax"
 )
 
 var nameTests = []struct {

--- a/tm-go/util/graph/tarjan_test.go
+++ b/tm-go/util/graph/tarjan_test.go
@@ -1,8 +1,9 @@
 package graph
 
 import (
-	"github.com/inspirer/textmapper/tm-go/util/container"
 	"testing"
+
+	"github.com/inspirer/textmapper/tm-go/util/container"
 )
 
 var tarjanTests = [][][]int{

--- a/tm-parsers/js/ast/factory.go
+++ b/tm-parsers/js/ast/factory.go
@@ -4,6 +4,7 @@ package ast
 
 import (
 	"fmt"
+
 	"github.com/inspirer/textmapper/tm-parsers/js"
 )
 

--- a/tm-parsers/js/ast/parser.go
+++ b/tm-parsers/js/ast/parser.go
@@ -4,6 +4,7 @@ package ast
 
 import (
 	"context"
+
 	"github.com/inspirer/textmapper/tm-parsers/js"
 )
 

--- a/tm-parsers/js/ast/tree.go
+++ b/tm-parsers/js/ast/tree.go
@@ -3,10 +3,11 @@
 package ast
 
 import (
-	"github.com/inspirer/textmapper/tm-parsers/js"
-	"github.com/inspirer/textmapper/tm-parsers/js/selector"
 	"sort"
 	"strings"
+
+	"github.com/inspirer/textmapper/tm-parsers/js"
+	"github.com/inspirer/textmapper/tm-parsers/js/selector"
 )
 
 // Tree is a parse tree for some content.

--- a/tm-parsers/tm/ast/factory.go
+++ b/tm-parsers/tm/ast/factory.go
@@ -4,6 +4,7 @@ package ast
 
 import (
 	"fmt"
+
 	"github.com/inspirer/textmapper/tm-parsers/tm"
 )
 

--- a/tm-parsers/tm/ast/tree.go
+++ b/tm-parsers/tm/ast/tree.go
@@ -3,10 +3,11 @@
 package ast
 
 import (
-	"github.com/inspirer/textmapper/tm-parsers/tm"
-	"github.com/inspirer/textmapper/tm-parsers/tm/selector"
 	"sort"
 	"strings"
+
+	"github.com/inspirer/textmapper/tm-parsers/tm"
+	"github.com/inspirer/textmapper/tm-parsers/tm/selector"
 )
 
 // Tree is a parse tree for some content.


### PR DESCRIPTION
	find . -type f -name '*.go' | xargs -I '{}' goimports -w '{}'