### PR TITLE
Fix "open syntax/token/token.go: no such file or directory" on `textmapper generate`

### DIFF
--- a/cmd/textmapper/generate.go
+++ b/cmd/textmapper/generate.go
@@ -129,6 +129,9 @@ func (w writer) Write(genfile, content string) error {
 		}
 		return nil
 	}
-
+	err := os.MkdirAll(filepath.Dir(path), 0755)
+	if err != nil {
+		return fmt.Errorf("Error creating directory: %w", err)
+	}
 	return os.WriteFile(path, []byte(content), 0644)
 }


### PR DESCRIPTION
When running `textmapper generate` , if the `token/` subdirectory is missing, the command will fail. If the directory exists, the command succeeds. This change makes sure all directories for each of the path to write are created.