### PR TITLE
Add tokenName and simplify tokenStr in cc_token_h.go.templ

### DIFF
--- a/gen/funcs.go
+++ b/gen/funcs.go
@@ -23,6 +23,7 @@ var funcMap = template.FuncMap{
 	"int_array":           intArray,
 	"int_array_columns":   intArrayColumns,
 	"str_literal":         strconv.Quote,
+	"stringify":           stringify,
 	"title":               strings.Title,
 	"lower":               strings.ToLower,
 	"first_lower":         firstLower,
@@ -46,6 +47,13 @@ var funcMap = template.FuncMap{
 	"last_id":             lastID,
 	"escape_reserved":     escapeReserved,
 	"unwrap_with_default": unwrapWithDefault,
+}
+
+func stringify(s string) string {
+	if len(s) >= 2 && s[0] == '"' && s[len(s)-1] == '"' {
+		return strconv.Quote(s[1 : len(s)-1])
+	}
+	return strconv.Quote(s)
 }
 
 func sum(a, b int) int {

--- a/gen/templates/cc_token_h.go.tmpl
+++ b/gen/templates/cc_token_h.go.tmpl
@@ -24,7 +24,15 @@ constexpr inline std::array<absl::string_view,
                             static_cast<size_t>(Token::NumTokens)>
     tokenStr = {
 {{- range .Tokens}}
-  {{if .Comment}}{{str_literal .Comment}}{{else}}{{str_literal .ID}}{{end}},
+  {{str_literal .ID}},{{if .Comment}}  // {{.Comment}}{{end}}
+{{- end}}
+};
+
+constexpr inline std::array<absl::string_view,
+                            static_cast<size_t>(Token::NumTokens)>
+    tokenName = {
+{{- range .Tokens}}
+  {{stringify .Name}},{{if .Comment}}  // {{.Comment}}{{end}}
 {{- end}}
 };
 


### PR DESCRIPTION
Add the array tokenName to the generated C++ code for easy lookup of a token's name.

Change the generated tokenStr array so that it always generates from the Token's ID and doesn't swizzle the comment into a string, which can be surprising.

