### PR TITLE
Add option for cc parser template to generate std::variant StackEntry.

### DIFF
--- a/compiler/options.go
+++ b/compiler/options.go
@@ -138,6 +138,9 @@ func (p *optionsParser) parseFrom(file ast.File) {
 		case "parseParams":
 			p.validLangs(opt.Key(), "cc")
 			opts.ParseParams = p.parseExpr(opt.Value(), opts.ParseParams).([]string)
+		case "variantStackEntry":
+			p.validLangs(opt.Key(), "cc")
+			opts.VariantStackEntry = p.parseExpr(opt.Value(), opts.VariantStackEntry).(bool)
 		case "skipByteOrderMark":
 			opts.SkipByteOrderMark = p.parseExpr(opt.Value(), opts.SkipByteOrderMark).(bool)
 		default:

--- a/gen/funcs_test.go
+++ b/gen/funcs_test.go
@@ -189,13 +189,15 @@ func TestParserAction(t *testing.T) {
 
 func TestCcParserAction(t *testing.T) {
 	tests := []struct {
-		input string
-		args  *grammar.ActionVars
-		want  string
+		input      string
+		args       *grammar.ActionVars
+		want       string
+		useVariant bool
 	}{
-		{"abc", varsOneBased(), "abc"},
-		{"$$ = $1", varsOneBased("%node", "a:0:expr"), "lhs.value.node = rhs[0].value.expr"},
-		{"$$ = @$ @1", varsOneBased("%node", "a:0:expr"), "lhs.value.node = lhs.sym.location rhs[0].sym.location"},
+		{"abc", varsOneBased(), "abc", false},
+		{"$$ = $1", varsOneBased("%node", "a:0:expr"), "lhs.value.node = rhs[0].value.expr", false},
+		{"$$ = @$ @1", varsOneBased("%node", "a:0:expr"), "lhs.value.node = lhs.sym.location rhs[0].sym.location", false},
+		{"$$ = $1", varsOneBased("%node", "a:0:expr"), "std::get<node>(lhs.value) = std::get<expr>(rhs[0].value)", true},
 	}
 
 	for _, tc := range tests {

--- a/gen/templates/cc_parser_cc.go.tmpl
+++ b/gen/templates/cc_parser_cc.go.tmpl
@@ -327,7 +327,7 @@ restart:
 {{- define "lookahead" -}}
 {{$stateType := bits_per_element .Parser.Tables.FromTo -}}
 ABSL_MUST_USE_RESULT bool lookahead(Lexer& lexer_to_copy, int32_t next,
-                                    int{{$stateType}}_t start, 
+                                    int{{$stateType}}_t start,
                                     int{{$stateType}}_t end) {
 {{ block "setupLookaheadLexer" . -}}
   Lexer lexer = lexer_to_copy;
@@ -709,7 +709,13 @@ void Parser::fetchNext(Lexer& lexer, std::vector<stackEntry>& stack) {
 {{ if (ne $act.Code "") -}}
 absl::Status Parser::action{{$index}}([[maybe_unused]] stackEntry& lhs,
                         [[maybe_unused]] const stackEntry* rhs) {
-{{ cc_parser_action $act.Code $act.Vars $act.Origin -}}
+{{ if and $.Options.VariantStackEntry (ne $act.Vars.LHSType "") -}}
+{{/* Initialize the variant tag so that semantic action code can use $$ as if it
+     was strongly typed. This allows convenient patterns like `$$ = nullptr;`.
+*/}}
+  lhs.value.emplace<{{$act.Vars.LHSType}}>();
+{{ end -}}
+{{ cc_parser_action $act.Code $act.Vars $act.Origin $.Options.VariantStackEntry -}}
   return absl::OkStatus();
 }
 {{ end -}}
@@ -794,7 +800,7 @@ ABSL_MUST_USE_RESULT Lexer::Location DefaultCreateLocationFromRHS(
 
 {{- define "Parse" -}}
 {{ $stateType := bits_per_element .Parser.Tables.FromTo -}}
-absl::Status Parser::Parse(int{{$stateType}}_t start, int{{$stateType}}_t end, 
+absl::Status Parser::Parse(int{{$stateType}}_t start, int{{$stateType}}_t end,
   Lexer& lexer) {
 {{ if .ReportTokens true -}}
   pending_symbols_.clear();

--- a/gen/templates/cc_parser_h.go.tmpl
+++ b/gen/templates/cc_parser_h.go.tmpl
@@ -37,11 +37,20 @@ struct stackEntry {
   symbol sym;
   int{{$stateType}}_t state = 0;
 {{ if .Parser.HasAssocValues -}}
+{{ if .Options.VariantStackEntry -}}
+  std::variant<
+{{ range .Parser.UnionFields -}}
+    {{.}},
+{{ end -}}
+    std::monostate
+  > value;
+{{ else -}}
   union {
 {{ range .Parser.UnionFields -}}
     {{.}};
 {{ end -}}
   } value;
+{{ end -}}
 {{ end -}}
 };
 

--- a/grammar/grammar.go
+++ b/grammar/grammar.go
@@ -223,4 +223,5 @@ type Options struct {
 	AbslIncludePrefix  string   // "absl" by default
 	DirIncludePrefix   string   // for generated headers
 	ParseParams        []string // parser fields initialized in the constructor
+	VariantStackEntry  bool     // whether to generate a std::variant stackEntry rather than a union. Default false.
 }


### PR DESCRIPTION
Add option for cc parser template to generate std::variant StackEntry.

std::variant has two primary advantages here:
- $$'s type can have a non-trivial destructor (e.g. string_view or vector)
- The grammar only needs to declare $$'s type. With the union, the grammar needs to also declare a name which is never referenced in the grammar. That is clunky